### PR TITLE
Fix out of VRAM error; document VRAM usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ By processing tiles in the latent space, the pipeline ensures smoother transitio
 
 * **Faster Execution:** Parallel tile processing reduces overall computation time.
 
-* **Reduced Memory Usage:** Unet quantization in float8 minimizes GPU memory requirements.
+* **Reduced Memory Usage:** Unet quantization in float8 minimizes GPU memory requirements (works with 8 GiB VRAM).
 
 * **Adaptability:** Works seamlessly across different resolutions and tile sizes.
 

--- a/app.py
+++ b/app.py
@@ -40,20 +40,27 @@ class Pipeline:
             
             self.controlnet = ControlNetUnionModel.from_pretrained(
                     "brad-twinkl/controlnet-union-sdxl-1.0-promax", torch_dtype=torch.float16
-                ).to(device=device)
-            self.vae = AutoencoderKL.from_pretrained("madebyollin/sdxl-vae-fp16-fix", torch_dtype=torch.float16).to(device=device)
+                )
+            self.vae = AutoencoderKL.from_pretrained("madebyollin/sdxl-vae-fp16-fix", torch_dtype=torch.float16)
 
             self.pipe = StableDiffusionXLControlNetTileSRPipeline.from_pretrained(
                 MODELS[model_id], controlnet=self.controlnet, vae=self.vae, torch_dtype=torch.float16, variant="fp16"
-            ).to(device=device)
+            )
 
             unet = UNet2DConditionModel.from_pretrained(MODELS[model_id], subfolder="unet", variant="fp16", use_safetensors=True)
             quantize_8bit(unet)  # << Enable this if you have limited VRAM
             self.pipe.unet = unet
 
-            self.pipe.enable_model_cpu_offload()
-            self.pipe.enable_vae_tiling()
-            self.pipe.enable_vae_slicing()
+            if True: # << Enable this if you have limited VRAM
+                self.pipe.enable_model_cpu_offload()
+            else:
+                self.controlnet.to(device=device)
+                self.vae.to(device=device)
+                self.pipe.to(device=device)
+
+            self.pipe.enable_vae_tiling() # << Enable this if you have limited VRAM
+            self.pipe.enable_vae_slicing() # << Enable this if you have limited VRAM
+
             self.last_loaded_model = model_id
             print(f"Model {model_id} loaded.")
 

--- a/infer.py
+++ b/infer.py
@@ -15,19 +15,24 @@ device = "cuda"
 # Initialize the models and pipeline
 controlnet = ControlNetUnionModel.from_pretrained(
     "brad-twinkl/controlnet-union-sdxl-1.0-promax", torch_dtype=torch.float16
-).to(device=device)
-vae = AutoencoderKL.from_pretrained("madebyollin/sdxl-vae-fp16-fix", torch_dtype=torch.float16).to(device=device)
+)
+vae = AutoencoderKL.from_pretrained("madebyollin/sdxl-vae-fp16-fix", torch_dtype=torch.float16)
 
 model_id = "SG161222/RealVisXL_V5.0"
 pipe = StableDiffusionXLControlNetTileSRPipeline.from_pretrained(
     model_id, controlnet=controlnet, vae=vae, torch_dtype=torch.float16, use_safetensors=True, variant="fp16"
-).to(device)
+)
 
 unet = UNet2DConditionModel.from_pretrained(model_id, subfolder="unet", variant="fp16", use_safetensors=True)
 quantize_8bit(unet)  # << Enable this if you have limited VRAM
 pipe.unet = unet
 
-pipe.enable_model_cpu_offload()  # << Enable this if you have limited VRAM
+if True: # << Enable this if you have limited VRAM
+    pipe.enable_model_cpu_offload()
+else:
+    controlnet.to(device=device)
+    vae.to(device=device)
+    pipe.to(device=device)
 pipe.enable_vae_tiling() # << Enable this if you have limited VRAM
 pipe.enable_vae_slicing() # << Enable this if you have limited VRAM
 

--- a/infer_diffusers.py
+++ b/infer_diffusers.py
@@ -9,15 +9,20 @@ device = "cuda"
 # Initialize the models and pipeline
 controlnet = ControlNetUnionModel.from_pretrained(
     "brad-twinkl/controlnet-union-sdxl-1.0-promax", torch_dtype=torch.float16
-).to(device=device)
-vae = AutoencoderKL.from_pretrained("madebyollin/sdxl-vae-fp16-fix", torch_dtype=torch.float16).to(device=device)
+)
+vae = AutoencoderKL.from_pretrained("madebyollin/sdxl-vae-fp16-fix", torch_dtype=torch.float16)
 
 model_id = "SG161222/RealVisXL_V5.0"
 pipe = StableDiffusionXLControlNetTileSRPipeline.from_pretrained(
     model_id, controlnet=controlnet, vae=vae, torch_dtype=torch.float16, use_safetensors=True, variant="fp16"
-).to(device)
+)
 
-pipe.enable_model_cpu_offload()  # << Enable this if you have limited VRAM
+if True: # << Enable this if you have limited VRAM
+    pipe.enable_model_cpu_offload()
+else:
+    controlnet.to(device=device)
+    vae.to(device=device)
+    pipe.to(device=device)
 pipe.enable_vae_tiling() # << Enable this if you have limited VRAM
 pipe.enable_vae_slicing() # << Enable this if you have limited VRAM
 


### PR DESCRIPTION
Running `.to(device=device)` on the models before CPU offload is enabled causes all of the models to briefly be loaded into VRAM simultaneously, causing an OOM error.

Fixes https://github.com/DEVAIEXP/mod-control-tile-upscaler-sdxl/issues/2